### PR TITLE
corrected: Zigbee2MQTTHelper.php line 2616

### DIFF
--- a/libs/Zigbee2MQTTHelper.php
+++ b/libs/Zigbee2MQTTHelper.php
@@ -2613,7 +2613,7 @@ trait Zigbee2MQTTHelper
 
                     case 'smoke_density_dbm':
                         if (!IPS_VariableProfileExists($ProfileName)) {
-                            $this->RegisterProfileFloat($ProfileName, 'Factory', '', ' ' . $expose['unit'], 0, 0, 0);
+                            $this->RegisterProfileFloat($ProfileName, 'Factory', '', ' ' . $expose['unit'], 0, 0, 0, 2);
                         }
                         break;
                     case 'display_brightness':


### PR DESCRIPTION
corrected: Fatal error: Uncaught ArgumentCountError: Too few arguments to function Zigbee2MQTTDevice::RegisterProfileFloat(), 7 passed in /var/lib/symcon/modules/.store/info.schnittcher.ips.zigbee2mqtt/libs/Zigbee2MQTTHelper.php on line 2616 and exactly 8 expected in /var/lib/symcon/modules/.store/info.schnittcher.ips.zigbee2mqtt/libs/VariableProfileHelper.php:120