### PR TITLE
ADD: permit_join_time

### DIFF
--- a/Bridge/locale.json
+++ b/Bridge/locale.json
@@ -19,7 +19,8 @@
             "Wrong last_seen setting in Zigbee2MQTT. Please set last_seen to epoch.": "Falsche Einstellung für last_seen in Zigbee2MQTT. Bitte last_seen auf epoch einstellen.",
             "Symcon Extension in Zigbee2MQTT is outdated. Please update the extension.": "Symcon Erweiterung in Zigbee2MQTT ist veraltet. Bitte Erweiterung updaten.",
             "No Symcon Extension in Zigbee2MQTT installed. Please install the extension.": "Symcon Erweiterung in Zigebee2MQTT nicht installiert. Bitte die Erweiterung installieren.",
-            "Extension Loaded": "Erweiterung geladen"
+            "Extension Loaded": "Erweiterung geladen",
+            "Permit Join Time", "Restzeit Netzwerk geöffnet"
         }
     }
 }

--- a/Bridge/locale.json
+++ b/Bridge/locale.json
@@ -20,7 +20,7 @@
             "Symcon Extension in Zigbee2MQTT is outdated. Please update the extension.": "Symcon Erweiterung in Zigbee2MQTT ist veraltet. Bitte Erweiterung updaten.",
             "No Symcon Extension in Zigbee2MQTT installed. Please install the extension.": "Symcon Erweiterung in Zigebee2MQTT nicht installiert. Bitte die Erweiterung installieren.",
             "Extension Loaded": "Erweiterung geladen",
-            "Permit Join Time", "Restzeit Netzwerk geöffnet"
+            "Permit Join Timeout", "Restzeit Netzwerk geöffnet"
         }
     }
 }

--- a/Bridge/locale.json
+++ b/Bridge/locale.json
@@ -20,7 +20,7 @@
             "Symcon Extension in Zigbee2MQTT is outdated. Please update the extension.": "Symcon Erweiterung in Zigbee2MQTT ist veraltet. Bitte Erweiterung updaten.",
             "No Symcon Extension in Zigbee2MQTT installed. Please install the extension.": "Symcon Erweiterung in Zigebee2MQTT nicht installiert. Bitte die Erweiterung installieren.",
             "Extension Loaded": "Erweiterung geladen",
-            "Permit Join Timeout", "Restzeit Netzwerk geöffnet"
+            "Permit Join Timeout": "Restzeit Netzwerk geöffnet"
         }
     }
 }

--- a/Bridge/module.php
+++ b/Bridge/module.php
@@ -76,6 +76,7 @@ class Zigbee2MQTTBridge extends IPSModule
         $this->EnableAction('log_level');
         $this->RegisterVariableBoolean('permit_join', $this->Translate('Allow joining the network'), '~Switch');
         $this->EnableAction('permit_join');
+        $this->RegisterVariableInteger('permit_join_timeout', $this->Translate('Permit Join Timeout'));
         $this->RegisterVariableBoolean('restart_required', $this->Translate('Restart Required'));
         $this->RegisterVariableInteger('restart_request', $this->Translate('Perform a restart'), 'Z2M.bridge.restart');
         $this->EnableAction('restart_request');
@@ -129,6 +130,9 @@ class Zigbee2MQTTBridge extends IPSModule
                 }
                 if (isset($Payload['permit_join'])) {
                     $this->SetValue('permit_join', $Payload['permit_join']);
+                }
+                if (isset($Payload['permit_join_timeout'])) {
+                    $this->SetValue('permit_join_timeout', $Payload['permit_join_timeout']);
                 }
                 if (isset($Payload['restart_required'])) {
                     $this->SetValue('restart_required', $Payload['restart_required']);
@@ -239,7 +243,7 @@ class Zigbee2MQTTBridge extends IPSModule
     public function SetPermitJoin(bool $PermitJoin)
     {
         $Topic = '/bridge/request/permit_join';
-        $Payload = ['value'=>$PermitJoin];
+        $Payload = ['value'=>$PermitJoin, 'time'=> 254];
         $Result = $this->SendData($Topic, $Payload);
         if ($Result) { //todo check the Response
             return true;

--- a/Bridge/module.php
+++ b/Bridge/module.php
@@ -133,6 +133,9 @@ class Zigbee2MQTTBridge extends IPSModule
                 }
                 if (isset($Payload['permit_join'])) {
                     $this->SetValue('permit_join', $Payload['permit_join']);
+                    if ($Payload['permit_join'] === false) {
+                    $this->SetValue('permit_join_timeout', 0);
+                    }
                 }
                 if (isset($Payload['permit_join_timeout'])) {
                     $this->SetValue('permit_join_timeout', $Payload['permit_join_timeout']);

--- a/Bridge/module.php
+++ b/Bridge/module.php
@@ -68,6 +68,7 @@ class Zigbee2MQTTBridge extends IPSModule
             ['info', $this->Translate('Information'), '', 0x00FF00],
             ['debug', $this->Translate('Debug'), '', 0x00FF00],
         ]);
+        $this->RegisterProfileInteger('Z2M.seconds', '', '', ' s', 0, 0, 1, 0);
         $this->RegisterVariableBoolean('state', $this->Translate('State'));
         $this->RegisterVariableBoolean('extension_loaded', $this->Translate('Extension Loaded'));
         $this->RegisterVariableString('extension_version', $this->Translate('Extension Version'));
@@ -76,7 +77,7 @@ class Zigbee2MQTTBridge extends IPSModule
         $this->EnableAction('log_level');
         $this->RegisterVariableBoolean('permit_join', $this->Translate('Allow joining the network'), '~Switch');
         $this->EnableAction('permit_join');
-        $this->RegisterVariableInteger('permit_join_timeout', $this->Translate('Permit Join Timeout'));
+        $this->RegisterVariableInteger('permit_join_timeout', $this->Translate('Permit Join Timeout'), 'Z2M.seconds');
         $this->RegisterVariableBoolean('restart_required', $this->Translate('Restart Required'));
         $this->RegisterVariableInteger('restart_request', $this->Translate('Perform a restart'), 'Z2M.bridge.restart');
         $this->EnableAction('restart_request');

--- a/Bridge/module.php
+++ b/Bridge/module.php
@@ -82,6 +82,8 @@ class Zigbee2MQTTBridge extends IPSModule
         $this->RegisterVariableInteger('restart_request', $this->Translate('Perform a restart'), 'Z2M.bridge.restart');
         $this->EnableAction('restart_request');
         $this->RegisterVariableString('version', $this->Translate('Version'));
+        $this->RegisterVariableString('zigbee_herdsman_converters', $this->Translate('Zigbee Herdsman Converters Version'));
+        $this->RegisterVariableString('zigbee_herdsman', $this->Translate('Zigbee Herdsman Version'));
         $this->RegisterVariableInteger('network_channel', $this->Translate('Network Channel'));
     }
 
@@ -140,6 +142,12 @@ class Zigbee2MQTTBridge extends IPSModule
                 }
                 if (isset($Payload['version'])) {
                     $this->SetValue('version', $Payload['version']);
+                }
+                if (isset($Payload['zigbee_herdsman_converters']['version'])) {
+                    $this->SetValue('zigbee_herdsman_converters', $Payload['zigbee_herdsman_converters']['version']);
+                }
+                if (isset($Payload['zigbee_herdsman']['version'])) {
+                    $this->SetValue('zigbee_herdsman', $Payload['zigbee_herdsman']['version']);
                 }
                 if (isset($Payload['config']['advanced']['last_seen'])) {
                     $this->SendDebug('last_seen', $Payload['config']['advanced']['last_seen'], 0);


### PR DESCRIPTION
@Nall-chan 
Habe mal das permit_join_time mit aufgenommen und der Aktivierung eine Laufzeit von 4:14 (wie im original) hinzugefügt, da es entsprechend der Vorgaben nicht mehr zulässig ist, das Zigbee-Netzwerk unbegrenzt geöffnet zu lassen. Die Restzeit der Öffnung wird jetzt als Variable angelegt und angezeigt.
Ich hoffe, dass ist okay für Dich.
