### PR TITLE
FIX: private static function convertIdentToPayloadKey($ident)

### DIFF
--- a/libs/Zigbee2MQTTHelper.php
+++ b/libs/Zigbee2MQTTHelper.php
@@ -1722,8 +1722,8 @@ trait Zigbee2MQTTHelper
         $identWithoutPrefix = str_replace('Z2M_', '', $ident);
         // Füge einen Unterstrich nach "state" ein, falls es im String enthalten ist, unabhängig von Groß/Kleinschreibung
         // Löst Probem, wenn das ident zum Beispiel "Z2M_Statel1" lautet
-        if (preg_match('/state/i', $identWithoutPrefix)) {
-            $identWithoutPrefix = preg_replace('/state/i', 'state_', $identWithoutPrefix);
+        if (preg_match('/state(?=[a-zA-Z])/i', $identWithoutPrefix)) {
+            $identWithoutPrefix = preg_replace('/state(?=[a-zA-Z])/i', 'state_', $identWithoutPrefix);
         }
         // Füge Unterstriche vor Großbuchstaben ein, außer am Anfang des Strings
         $payloadKey = strtolower(preg_replace('/(?<!^)([A-Z])/', '_$1', $identWithoutPrefix));

--- a/libs/Zigbee2MQTTHelper.php
+++ b/libs/Zigbee2MQTTHelper.php
@@ -1720,7 +1720,13 @@ trait Zigbee2MQTTHelper
         // Gehört zu RequestAction
         // Wandelt den Ident zu einem gültigen Expose um
         $identWithoutPrefix = str_replace('Z2M_', '', $ident);
-        $payloadKey = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $identWithoutPrefix));
+        // Füge einen Unterstrich nach "state" ein, falls es im String enthalten ist, unabhängig von Groß/Kleinschreibung
+        // Löst Probem, wenn das ident zum Beispiel "Z2M_Statel1" lautet
+        if (preg_match('/state/i', $identWithoutPrefix)) {
+            $identWithoutPrefix = preg_replace('/state/i', 'state_', $identWithoutPrefix);
+        }
+        // Füge Unterstriche vor Großbuchstaben ein, außer am Anfang des Strings
+        $payloadKey = strtolower(preg_replace('/(?<!^)([A-Z])/', '_$1', $identWithoutPrefix));
         return $payloadKey;
     }
 


### PR DESCRIPTION
Wenn bei Schaltmodulen mit z.B. 4 integrierten Aktoren der ident "Z2M_Statel1" heist, also nach dem State noch in Kleinbuschstaben die line (l1, l2,l3,l4,...) genannt wird, wird das expose entsprechend anders formatiert. Ziel: Erhalt der Abwärtskompatibilität der bereits angelegten Variablen.